### PR TITLE
Raise ValueError if the input could not be syllabified.

### DIFF
--- a/syllabify.py
+++ b/syllabify.py
@@ -22,6 +22,8 @@
 # 
 # syllabify.py: prosodic parsing of ARPABET entries
 
+from itertools import chain
+
 ## constants
 slax   = {'IH1', 'IH2', 'EH1', 'EH2', 'AE1', 'AE2', 'AH1', 'AH2', 
                                                     'UH1', 'UH2',}
@@ -163,7 +165,14 @@ def syllabify(pron, alaska_rule=True):
             coda.append(onsets[i].pop(0))
         # store coda
         codas.insert(i - 1, coda)
-    return zip(onsets, nuclei, codas)
+
+    ## verify that all segments are included in the ouput
+    output = zip(onsets, nuclei, codas)
+    flat_output = list(chain.from_iterable(chain.from_iterable(output)))
+    if flat_output != mypron:
+        raise ValueError("could not syllabify {}, got {}".format(mypron, flat_output))
+
+    return output
 
 
 def pretty(syllab):


### PR DESCRIPTION
This fixes kylebgorman/syllabify#1. I didn't do any formal performance testing, but informally the entirety of CMUDict can be syllabified very quickly. The impact of using chain twice is probably insignificant compared to the two syllabification passes.
